### PR TITLE
#29: Polling interval starts when previous cycle finishes

### DIFF
--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -7,10 +7,7 @@ Date: ???
 ### Bugs
 
 - #22: Change log level from debug to information for start polling message.
-
-### Features
-
-### Miscellaneous
+- #29: Polling interval to be time between cycles
 
 ### Dependent Packages
 

--- a/src/Stravaig.Configuration.SqlServer.Tests/FakeDataLoader.cs
+++ b/src/Stravaig.Configuration.SqlServer.Tests/FakeDataLoader.cs
@@ -39,4 +39,8 @@ public class FakeSqlServerConfigurationWatcher : ISqlServerConfigurationWatcher
     {
         _provider = provider;
     }
+
+    public void Dispose()
+    {
+    }
 }

--- a/src/Stravaig.Configuration.SqlServer.Tests/SqlServerConfigurationProviderTests.cs
+++ b/src/Stravaig.Configuration.SqlServer.Tests/SqlServerConfigurationProviderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Shouldly;
 using Stravaig.Configuration.SqlServer.Glue;
@@ -12,11 +13,11 @@ namespace Stravaig.Configuration.SqlServer.Tests;
 public class SqlServerConfigurationProviderTests
 {
     private const string DummyConnectionString = "Server=localhost;Database=testing";
-    private FakeDataLoader _fakeLoader;
-    private FakeSqlServerConfigurationWatcher _fakeWatcher;
-    private ILoggerFactory _loggerFactory;
-    private TestCaptureLoggerProvider _loggerProvider;
-    private SqlServerConfigurationSource _source;
+    private FakeDataLoader _fakeLoader = new ();
+    private FakeSqlServerConfigurationWatcher _fakeWatcher = new ();
+    private ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+    private TestCaptureLoggerProvider _loggerProvider = new ();
+    private SqlServerConfigurationSource _source = new (DummyConnectionString);
 
     [SetUp]
     public void Setup()

--- a/src/Stravaig.Configuration.SqlServer.Tests/SqlServerConfigurationSourceExtensionTests.cs
+++ b/src/Stravaig.Configuration.SqlServer.Tests/SqlServerConfigurationSourceExtensionTests.cs
@@ -51,33 +51,4 @@ public class SqlServerConfigurationSourceExtensionTests
         descriptionLog.PropertyDictionary["connectionTimeout"].ShouldBe(5);
         descriptionLog.PropertyDictionary["commandTimeout"].ShouldBe(10);
     }
-    
-    [Test]
-    public void CreateLoggerWarnsOfInterleavePossibility()
-    {
-        var source = new SqlServerConfigurationSource(DummyConnectionString, expectLogger: true, refreshInterval: TimeSpan.FromSeconds(12), commandTimeout: TimeSpan.FromSeconds(30));
-        var replayLogger = (ReplayLogger<SqlServerConfigurationProvider>)source.CreateLogger();
-        var captureLogger = new TestCaptureLogger<SqlServerConfigurationProvider>();
-        replayLogger.Replay(captureLogger);
-
-        var logs = captureLogger.GetLogs();
-        logs.RenderLogs(Formatter.SimpleBySequence, Sink.Console);
-
-        var descriptionLog = logs[1];
-        descriptionLog.OriginalMessage.ShouldBe("SQL Server Configuration Provider will retrieve from [{serverName}].[{databaseName}].[{schemaName}].[{tableName}] {frequency}. Will wait {connectionTimeout} seconds to connect, and {commandTimeout} seconds to retrieve data.");
-        descriptionLog.PropertyDictionary["serverName"].ShouldBe("localhost");
-        descriptionLog.PropertyDictionary["databaseName"].ShouldBe("testing");
-        descriptionLog.PropertyDictionary["schemaName"].ShouldBe("Stravaig");
-        descriptionLog.PropertyDictionary["tableName"].ShouldBe("AppConfiguration");
-        descriptionLog.PropertyDictionary["frequency"].ShouldBe("every 12 seconds");
-        descriptionLog.PropertyDictionary["connectionTimeout"].ShouldBe(5);
-        descriptionLog.PropertyDictionary["commandTimeout"].ShouldBe(30);
-
-        var warningLog = logs[2];
-        warningLog.OriginalMessage.ShouldBe("The refresh interval, {refreshInterval} seconds, should be greater than combined connection, {connectionTimeout} seconds, and command, {commandTimeout} seconds, timeouts. A new refresh cycle may start before the previous cycle is complete.");
-        warningLog.LogLevel.ShouldBe(LogLevel.Warning);
-        warningLog.PropertyDictionary["refreshInterval"].ShouldBe(12);
-        warningLog.PropertyDictionary["connectionTimeout"].ShouldBe(5);
-        warningLog.PropertyDictionary["commandTimeout"].ShouldBe(30);
-    }
 }

--- a/src/Stravaig.Configuration.SqlServer/Glue/ISqlServerConfigurationWatcher.cs
+++ b/src/Stravaig.Configuration.SqlServer/Glue/ISqlServerConfigurationWatcher.cs
@@ -1,8 +1,9 @@
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Stravaig.Configuration.SqlServer.Glue;
 
-internal interface ISqlServerConfigurationWatcher
+internal interface ISqlServerConfigurationWatcher : IDisposable
 {
     void EnsureStarted();
     void AttachLogger(ILogger logger);

--- a/src/Stravaig.Configuration.SqlServer/Glue/Log.cs
+++ b/src/Stravaig.Configuration.SqlServer/Glue/Log.cs
@@ -65,9 +65,12 @@ public static partial class Log
         Message = "SQL Server Configuration Provider will retrieve from [{serverName}].[{databaseName}].[{schemaName}].[{tableName}] {frequency}. Will wait {connectionTimeout} seconds to connect, and {commandTimeout} seconds to retrieve data.")]
     public static partial void InitialProviderDescription(this ILogger logger, string serverName, string databaseName, string schemaName, string tableName, string frequency, int connectionTimeout, int commandTimeout);
     
+    // Event Id 11 was retired as the log message was no longer relevant.
+    
     [LoggerMessage(
-        EventId = 11,
-        Level = LogLevel.Warning,
-        Message = "The refresh interval, {refreshInterval} seconds, should be greater than combined connection, {connectionTimeout} seconds, and command, {commandTimeout} seconds, timeouts. A new refresh cycle may start before the previous cycle is complete.")]
-    public static partial void WarnOfCycleInterleave(this ILogger logger, int refreshInterval, int connectionTimeout, int commandTimeout);
+        EventId = 12,
+        Level = LogLevel.Debug,
+        Message = "Waiting {refreshInterval} seconds until the next polling cycle.")]
+    public static partial void WaitingForNextCycle(this ILogger logger, int refreshInterval);
+
 }

--- a/src/Stravaig.Configuration.SqlServer/Glue/NullSqlServerConfigurationWatcher.cs
+++ b/src/Stravaig.Configuration.SqlServer/Glue/NullSqlServerConfigurationWatcher.cs
@@ -1,8 +1,9 @@
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Stravaig.Configuration.SqlServer.Glue;
 
-internal class NullSqlServerConfigurationWatcher : ISqlServerConfigurationWatcher
+internal sealed class NullSqlServerConfigurationWatcher : ISqlServerConfigurationWatcher
 {
     internal static readonly NullSqlServerConfigurationWatcher Instance = new ();
     public void EnsureStarted()
@@ -10,6 +11,10 @@ internal class NullSqlServerConfigurationWatcher : ISqlServerConfigurationWatche
     }
 
     public void AttachLogger(ILogger logger)
+    {
+    }
+
+    public void Dispose()
     {
     }
 }

--- a/src/Stravaig.Configuration.SqlServer/Glue/SqlServerConfigurationSourceExtensions.cs
+++ b/src/Stravaig.Configuration.SqlServer/Glue/SqlServerConfigurationSourceExtensions.cs
@@ -21,12 +21,6 @@ internal static class SqlServerConfigurationSourceExtensions
             (int)source.ConnectionTimeout.TotalSeconds,
             (int)source.CommandTimeout.TotalSeconds);
         
-        if (source.ConnectionTimeout + source.CommandTimeout > source.RefreshInterval)
-            logger.WarnOfCycleInterleave(
-                (int)source.RefreshInterval.TotalSeconds,
-                (int)source.ConnectionTimeout.TotalSeconds,
-                (int)source.CommandTimeout.TotalSeconds);
         return logger;
-
     }
 }

--- a/src/Stravaig.Configuration.SqlServer/SqlServerConfigurationProvider.cs
+++ b/src/Stravaig.Configuration.SqlServer/SqlServerConfigurationProvider.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Stravaig.Configuration.SqlServer.Glue;
 
 namespace Stravaig.Configuration.SqlServer;
@@ -44,6 +43,12 @@ public class SqlServerConfigurationProvider : ConfigurationProvider
 
     public override void Load()
     {
+        UpdateData();
+        _watcher.EnsureStarted();
+    }
+    
+    private void UpdateData()
+    {
         try
         {
             _logger.LoadingConfigurationData();
@@ -53,14 +58,13 @@ public class SqlServerConfigurationProvider : ConfigurationProvider
         {
             _logger.FailedToGetConfigurationData(ex, _source.SchemaName, _source.TableName, _source.DatabaseName, _source.ServerName, ex.Message);
         }
-        _watcher.EnsureStarted();
-     }
+    }
     
     internal void Reload()
     {
         // Get existing data
         var oldData = Data;
-        Load();
+        UpdateData();
 
         if (DataDifferent(oldData, Data))
         {


### PR DESCRIPTION
# Change polling interval to time between cycles

## Issue

This PR addresses Issue #29.

This changes the polling interval to the time between cycles rather than an absolute time. This will prevent any delays getting information from SQL Server in one cycle impacting the subsequent cycle.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the `readme.md` file
- [x] I have bumped the version number in the `version.txt`
- [x] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.
